### PR TITLE
Add spell check process to guides

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1,0 +1,16 @@
+# markdown-spellcheck spelling configuration file
+# Format - lines beginning # are comments
+# global dictionary is at the start, file overrides afterwards
+# one word per line, to define a file override use ' - filename'
+# where filename is relative to this configuration file
+Cruikshanks
+gitflow
+onboarding
+ - process/new-projects/README.md
+N.B.
+ - README.md
+DST
+how-to's
+ThoughtBot
+v3
+OGL

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,12 @@ If you'd like to suggest a change contributions should be submitted via a pull r
 
 If in doubt speak to **Alan Cruikshanks** before creating the PR.
 
+## Checking your work
+
+We use [markdown-spellcheck](https://www.npmjs.com/package/markdown-spellcheck) to check content for spelling errors. We recommend you install and run this before making a commit. We will check contributions using `mdspell --en-gb -n '**/*.md'`.
+
 ## Getting feedback
 
 Feedback will be provided by the team within the PR. Decisions will be documented and reasons given.
 
-We're a team that want to encourage others to suggest ways we can improve. We'll always endeavor to be positive and professional with any comments we make about your contribution, but let us know if you feel we failed.
+We're a team that want to encourage others to suggest ways we can improve. We'll always endeavour to be positive and professional with any comments we make about your contribution, but let us know if you feel we failed.


### PR DESCRIPTION
To prevent easily made spelling errors which should also help improve the quality of the guides, this change adds a `.spelling` file which can be used in conjunction with [markdown-spellcheck](https://www.npmjs.com/package/markdown-spellcheck) to check for spelling errors in the markdown files.

`.spelling` is used to maintain a list of additional words that should be checked, or words that can be ignored. This change also includes initial spelling corrections as a result of running `mdspell`, and an update to CONTRIBUTION.md with instructions on how to use `mdspell`.