### PR TITLE
Add markdownlint to CI process

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -12,3 +12,5 @@ N.B.
 how-to's
 ThoughtBot
 v3
+ - CONTRIBUTING.md
+markdownlint

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,16 @@ node_js:
 git:
   depth: 3
 
+before_install:
+   - rvm install 2.2.0
+
 before_script:
   - npm install -g markdown-spellcheck
+  - gem install mdl
 
 script:
   - mdspell --en-gb --ignore-numbers --ignore-acronyms --report '**/*.md'
+  - mdl --style md_style.rb $PWD
 
 branches:
   only:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,11 @@ If in doubt speak to **Alan Cruikshanks** before creating the PR.
 
 ## Checking your work
 
-We use [markdown-spellcheck](https://www.npmjs.com/package/markdown-spellcheck) to check content for spelling errors. We recommend you install and run this before making a commit. We will check contributions using `mdspell --en-gb --ignore-numbers --ignore-acronyms '**/*.md'`.
+We use [markdown-spellcheck](https://www.npmjs.com/package/markdown-spellcheck) to check content for spelling errors. We check contributions using `mdspell --en-gb --ignore-numbers --ignore-acronyms '**/*.md'`.
+
+We use [markdownlint](https://github.com/mivok/markdownlint) to check the files have a consistent style. We check contributions using `mdl --style md_style.rb $PWD`.
+
+We recommend you install these tools, and then run before before pushing your commits.
 
 ## Getting feedback
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Please read the [contribution guidelines](/CONTRIBUTING.md) before submitting a 
 
 THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
 
-http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+<http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3>
 
 The following attribution statement MUST be cited in your products and applications when using this information.
 

--- a/md_style.rb
+++ b/md_style.rb
@@ -1,0 +1,9 @@
+all
+
+# https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md013---line-length
+# We exclude this rule because we believe it is easier to maintain the content
+# if there is no limit on line lengths. Most editors can wrap the text and
+# GitHub renders the content without issue. If we enforced a limit it would mean
+# when editing a paragraph contributors would not only need to edit the content,
+# but then also reformat it. We feel this last step is unnecessary.
+exclude_rule 'MD013'

--- a/process/new-projects/README.md
+++ b/process/new-projects/README.md
@@ -1,6 +1,6 @@
 # New projects
 
-*N.B. This guide currently only relates to new projects on GitHub.*
+N.B. This guide currently only relates to new projects on GitHub.
 
 ## Get a repo
 


### PR DESCRIPTION
As part of ensuring the content remains consistent this change updates the Travis-CI build to include a markdownlint step.

It also includes intial rule configuration for the linter, corrections, and details on how to use it in the contribution guide.