### PR TITLE
Remove markdown-spellcheck from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,12 @@
-language: node_js
-
-cache:
-  directories:
-    - node_modules
-
-node_js:
-  - node
+language: ruby
 
 git:
   depth: 3
 
-before_install:
-   - rvm install 2.2.0
-
 before_script:
-  - npm install -g markdown-spellcheck
   - gem install mdl
 
 script:
-  - mdspell --en-gb --ignore-numbers --ignore-acronyms --report '**/*.md'
   - mdl --style md_style.rb $PWD
 
 branches:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,20 +6,27 @@ If you'd like to suggest a change contributions should be submitted via a pull r
 
 ## What not to include
 
-* Deployment guides or details
-* Details of infrastructure
-* Details about any service's back office processes
-* Personal contact information
+- Deployment guides or details
+- Details of infrastructure
+- Details about any service's back office processes
+- Personal contact information
 
 If in doubt speak to **Alan Cruikshanks** before creating the PR.
 
 ## Checking your work
 
-We use [markdown-spellcheck](https://www.npmjs.com/package/markdown-spellcheck) to check content for spelling errors. We check contributions using `mdspell --en-gb --ignore-numbers --ignore-acronyms '**/*.md'`.
+We recommend using [markdown-spellcheck](https://www.npmjs.com/package/markdown-spellcheck) to check content for spelling errors. Call it in the following way `mdspell --en-gb --ignore-numbers --ignore-acronyms --report '**/*.md'`. This ensures
 
-We use [markdownlint](https://github.com/mivok/markdownlint) to check the files have a consistent style. We check contributions using `mdl --style md_style.rb $PWD`.
+- You are using en-gb as your language `--en-gb`
+- Numbers are not reported as false positives `--ignore-numbers`
+- Acronyms are not reported as false positives `--ignore-acronyms`
+- You avoid the default interactive mode `--report`
 
-We recommend you install these tools, and then run before before pushing your commits.
+The last option is needed because our guides feature code examples. **markdown-spellcheck** includes them in the checks because it does not handle text in backticks. You'd have to deal with a large number of false positives which would be slow to go through and might put you off writing more guides. We want to avoid that! So currently it's not part of the build but we hope to include it if this feature becomes available.
+
+For now it'll simply report all errors and you can then deal with actually spelling errors directly.
+
+We use [markdownlint](https://github.com/mivok/markdownlint) to check the files have a consistent style as part of a CI process. We check contributions using `mdl --style md_style.rb $PWD`. We recommend you install this and run it before pushing your commits.
 
 ## Getting feedback
 

--- a/process/new-projects/README.md
+++ b/process/new-projects/README.md
@@ -6,10 +6,10 @@ N.B. This guide currently only relates to new projects on GitHub.
 
 Contact **Alan Cruikshanks** or **David Blackburn** for a new repo to be created. They'll need
 
-* A name for the project
-* A description
-* Whether the repo is to be private or public
-* Team or teams to be assigned
+- A name for the project
+- A description
+- Whether the repo is to be private or public
+- Team or teams to be assigned
 
 **Do not create it under your own user account!** Though repo's can be transferred at a later date, it is simpler and clearer if the repo originates within the [Environment Agency](https://github.com/EnvironmentAgency) organisation on GitHub.
 


### PR DESCRIPTION
It has recently been found by the team that **markdown-spellcheck** does not ignore text in backticks. This tends to be code so is not expected to to be recognised text, but **markdown-spellcheck** still flags it and forces you to go through each false-positive using its interactive command line process.

Till a better alternative can be found, or until we can add this option to ignore text in backticks to the package we need to remove it from the build process. The guides and documents we write tend to be 'tech' heavy and feature loads of code examples, and having to deal with this issue is more likely to dissuade team members from writing documentation, something we strongly wish to avoid.

The changes include in this are

- Remove call to markdown-spellcheck from travis.yml
- Switch travis.yml to be a ruby build rather than node build
- Update contribution guidance to recommend people run the tool, but not require it