### PR TITLE
Add missing link to pr guide to root

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -17,4 +17,5 @@ v3
 Thoughbot's
 markdownlint
  - CONTRIBUTING.md
+en-gb
 markdownlint

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ These guides relate to the work of the Digital Service Team (south), an Environm
 
 ## Guides
 
-* [Process](/process)
-  * [New projects](/process/new-projects)
-* *More to come, the process of conversion and documentation is ongoing!*
+- [Process](/process)
+  - [New projects](/process/new-projects)
+  - [Pull requests](/process/pull-request)
+- *More to come, the process of conversion and documentation is ongoing!*
 
 ## About
 

--- a/process/README.md
+++ b/process/README.md
@@ -2,4 +2,5 @@
 
 Guides covering how we do things
 
-* [New projects](/process/new-projects)
+- [New projects](/process/new-projects)
+- [Pull requests](/process/pull-request)


### PR DESCRIPTION
Recently we added a new guide covering the PR process within the team (#4). However we forgot to add a link to it to in the list of guides on the root README, plus one in the `process` root README.

This change corrects that oversight by adding the missing links.