### PR TITLE
Add missing links and README's to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ These guides relate to the work of the Digital Service Team (south), an Environm
 - [Process](/process)
   - [New projects](/process/new-projects)
   - [Pull requests](/process/pull-request)
+- [Services](/services)
+  - [Register your waste exemptions](/services/wex)
+    - [State engine](/services/wex/state-engine)
+- [Style](/style)
+  - [Markdown](/style/markdown)
 - *More to come, the process of conversion and documentation is ongoing!*
 
 ## About

--- a/services/README.md
+++ b/services/README.md
@@ -1,0 +1,6 @@
+# Services
+
+Provides details and guides specific to a service.
+
+- [Register your waste exemptions](/services/wex)
+  - [State engine](/services/wex/state-engine)

--- a/services/wex/README.md
+++ b/services/wex/README.md
@@ -1,0 +1,20 @@
+# Register your waste exemptions
+
+To quote the intro on the projects README.
+
+> If your business produces waste or emissions that pollute you may require an environmental permit. However you may also be able to get an exemption if your business activities are considered to be easily controlled and only create low risks of pollution.
+>
+> The waste exemptions service is used by organisations to apply for an exemption.
+
+The service itself is built from six different repositories
+
+- [Waste exemptions](https://github.com/EnvironmentAgency/waste-exemptions)
+- [Waste exemptions back office](https://github.com/EnvironmentAgency/waste-exemptions-back-office)
+- [Waste exemptions shared](https://github.com/EnvironmentAgency/waste-exemptions-shared)
+- [Front office core](https://github.com/EnvironmentAgency/front-office-core)
+- [Back office core](https://github.com/EnvironmentAgency/back-office-core)
+- [Digital services core](https://github.com/EnvironmentAgency/digital-services-core)
+
+## Guides
+
+- [State engine](/services/wex/state-engine)


### PR DESCRIPTION
In PR's #9 and #13 new guides were added but the root README was not updated with links to them, and README's were not placed in the roots of some of the new folders.

Having links to all the guides on the root README aids visibility of the content, and having a README in each folder ensures consistency and an opportunity to provide details to the purpose of a section of the guides.

This changes adds the missing links and README's.