### PR TITLE
Update PR guide to use labels rather emojis

### DIFF
--- a/process/pull-request/README.md
+++ b/process/pull-request/README.md
@@ -91,9 +91,9 @@ git rebase origin/master
 
 ## Get it looked at
 
-When you're finished and have pushed your last commit add a comment with the :eyes: emoji.
+When you're finished and have pushed your last commit add the label **ready for review** to the PR.
 
-Another collaborator should then come back to confirm they are doing the PR. The two of you will then work to confirm the changes are OK. When the other collaborator is happy they will add the comment ':ship: it!'
+Another collaborator should then pick up the PR for review, at which point they will change the label to **in review**. The two of you will then work to confirm the changes are OK. When the other collaborator is happy they will change the label to **ship it**.
 
 ## Completing the commit
 


### PR DESCRIPTION
Initial feedback on the new PR process from the team was that it was difficult to see which PR's needed reviewing. It was suggested that using the labels provided by GitHub rather than comments with emoji's would make it clearer and easier to see which PR's needed reviewing.

This change updates the PR process to use labels, but also includes using labels to cover

- ready to review
- in review
- ship it