### PR TITLE
Fix missing guide link to release process in WEX

### DIFF
--- a/services/wex/README.md
+++ b/services/wex/README.md
@@ -17,4 +17,5 @@ The service itself is built from six different repositories
 
 ## Guides
 
+- [Solution release process](/services/wex/solution-release-process.md)
 - [State engine](/services/wex/state-engine.md)


### PR DESCRIPTION
This fixes #20. A link to the [Solution release process](https://github.com/EnvironmentAgency/dst-guides/blob/master/services/wex/solution-release-process.md#solution-release-process) was missing from the WEX readme.