### PR TITLE
Add rule on line wrapping for markdown files

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -13,6 +13,7 @@ Setex
 enrollment
 hotfix
 Sourcetree
+gitignore
  - process/new_projects.md
 N.B.
  - README.md
@@ -28,3 +29,9 @@ atx
 _business
 _sector
 _at
+ - services/frae/solution-release-process.md
+github
+_to
+_version
+_x-x-x
+x.x.x

--- a/style/markdown.md
+++ b/style/markdown.md
@@ -1,5 +1,11 @@
 # Markdown
 
+When writing markdown the overall goal is to make the content as accessible to the *reader* as possible. The guide below is to provide some consistency for an *editor* working across various projects.
+
+TL;DR Make it nice, but try and be consistent with the guide if you can.
+
+## Style guide
+
 Use *atx* style headers instead of *Setex*, and don't close them.
 
     # Use atx style headers
@@ -31,3 +37,5 @@ When leading into a list or code block don't put a period, colon or semi-colon a
     ```
 
 When mentioning tools or gems, link to them on first reference and then highlight them in *bold*.
+
+Don't attempt to manually wrap lines, for example at 80 characters.


### PR DESCRIPTION
Some advocate that lines in Markdown files, as well as code files, should be manually wrapped at 80 characters. This means your file will be better rendered in a terminal for example.

However we find that it inhibits editing and therefore contributions. Attempting to make edits to an existing block of text could lead to having to manually 'shuffle' a large number of lines.

Also we expect readers to access the files either through the browser (via GitHub) or in a text editor like Sublime, Atom or VS Code. These all automatically render the content to fit the current view making manual wrapping unnecessary.

This commit covers the following changes

- Add rule to `style/markdown.md`
- Correct spelling issues found in current version of the guides (housekeeping)