### PR TITLE
Update WEX details after normalising gems

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -14,6 +14,26 @@ enrollment
 hotfix
 Sourcetree
 gitignore
+brakeman
+rubocop
+config
+StandardJS
+nodejs
+dst-guides
+Sagar
+classpath
+Gemfile
+npm
+frontend
+Nomensa
+Hakiri
+Hapi
+DependencyCI
+copyfree
+Airbrake
+Errbit
+node-airbrake
+node-hapi-airbrake
  - process/new_projects.md
 N.B.
  - README.md
@@ -23,6 +43,7 @@ markdownlint
  - CONTRIBUTING.md
 en-gb
 markdownlint
+_drink
  - style/markdown.md
 atx
  - services/wex/state_engine.md

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ These guides relate to the work of Digital Service teams in the Environment Agen
     - [Solution release process](/services/frae/solution-release-process.md)
     - [State engine](/services/frae/state_engine.md)
 - [Style](/style)
-  - [Javascript](/style/javascript.md)
+  - [JavaScript](/style/javascript.md)
   - [Markdown](/style/markdown.md)
   - [Ruby](/style/ruby.md)
 - *More to come, the process of conversion and documentation is ongoing!*

--- a/applications/software-libraries.md
+++ b/applications/software-libraries.md
@@ -4,7 +4,7 @@ The following describes the approach we adopt when referencing or including othe
 
 It covers the use of **any software code** that is not directly owned by the Environment Agency but is included in a deployable application bundle.
 
-Examples include JAR files on the classpath, Ruby Gems installed by bundler, NPM packages, javascript libraries referenced in web pages and code copied from Stack Overflow.
+Examples include JAR files on the classpath, Ruby Gems installed by bundler, NPM packages, JavaScript libraries referenced in web pages and code copied from Stack Overflow.
 
 It is _not_ intended to cover remote or entirely external services that an application makes use of, such as databases, operating systems, web services, etc.
 
@@ -20,7 +20,7 @@ Ensure that any client-side libraries you use are captured in your dependencies.
 
 Again, this sounds obvious.  However, not all client-side frameworks and libraries are necessarily included in your application through the likes of bundler or npm.
 
-> As an example: The GOV.UK frontend toolkit includes the GPL-licensed Nomensa accessible media player.  If you link to the Nomensa player in your own client-side Javascript then you will have to GPL *all* your client-side code.  The toolkit's MIT licence does not cover this dependency so you will need to be aware of it.
+> As an example: The GOV.UK frontend toolkit includes the GPL-licensed Nomensa accessible media player.  If you link to the Nomensa player in your own client-side JavaScript then you will have to GPL *all* your client-side code.  The toolkit's MIT licence does not cover this dependency so you will need to be aware of it.
 
 ## Use a dependency checker
 

--- a/services/wex/README.md
+++ b/services/wex/README.md
@@ -6,14 +6,11 @@ To quote the intro on the projects README.
 >
 > The waste exemptions service is used by organisations to apply for an exemption.
 
-The service itself is built from six different repositories
+The service itself is built from 3 different repositories
 
 - [Waste exemptions](https://github.com/EnvironmentAgency/waste-exemptions)
 - [Waste exemptions back office](https://github.com/EnvironmentAgency/waste-exemptions-back-office)
 - [Waste exemptions shared](https://github.com/EnvironmentAgency/waste-exemptions-shared)
-- [Front office core](https://github.com/EnvironmentAgency/front-office-core)
-- [Back office core](https://github.com/EnvironmentAgency/back-office-core)
-- [Digital services core](https://github.com/EnvironmentAgency/digital-services-core)
 
 ## Guides
 

--- a/services/wex/solution-release-process.md
+++ b/services/wex/solution-release-process.md
@@ -2,51 +2,19 @@
 
 This details the process of updating each of the projects that make up the Waste Exemptions service solution.
 
-It's focus is the **code**, not the release process itself e.g. submitting a *Request for Change*, ensuring deployment is followed by a [smoke test](https://en.wikipedia.org/wiki/Smoke_testing_(software)). The aim is to document that in the guides at a later date.
-
-## [Digital services core](https://github.com/EnvironmentAgency/digital-services-core)
-
-- When ready for release create branch off `master` called *release/update_to_version_x-x-x*.
-
-- Push empty commit as normal with message
-
-> Update version to x.x.x ready for release
->
-> As part of releasing a new version of the Waste exemptions registration service we are also updating and tagging the engines it uses so we have a clear understanding of what is being used in production.
-
-- Update the version number (normally found in `lib/engine_name/version.rb`) to match
-
-- Run `bundle install` (**Critical** failure to do so can lead to build issues on the CI server)
-
-- Do a `git add --all` followed by a `git commit --amend`
-
-- Save changes and force push `git push -f`
-
-- Assuming build is successful merge the PR in GitHub
-
-- Ensure `master` is checked out and then create tag `git tag -a vx.x.x -m "Release of x.x.x"`
-
-- Push tag to GitHub `git push origin vx.x.x`
+It's focus is the **code**, not the release process itself (i.e. the submission of a *Request for Change*, ensuring deployment is followed by a [smoke test](https://en.wikipedia.org/wiki/Smoke_testing_(software)). The aim is to document that in the guides at a later date.
 
 ## [Waste exemptions shared](https://github.com/EnvironmentAgency/waste-exemptions-shared)
 
-- When ready for release create branch off `master` called *release/update_to_version_x-x-x*.
+- When ready for release create branch off `master` called *release/x-x-x*.
 
 - Push empty commit as normal with message
 
-> Update version to x.x.x ready for release
+> Release of version x.x.x
 >
-> As part of releasing a new version of the Waste exemptions registration service we are also updating and tagging the engines it uses so we have a clear understanding of what is being used in production.
+> Creating a production ready release of this gem.
 
-- Update the version number (normally found in `lib/engine_name/version.rb`) to match
-
-- Update the reference to **Digital Services Core** in the `Gemfile` to point to latest tag
-
-```ruby
-gem 'digital_services_core',
-  git: 'https://github.com/EnvironmentAgency/digital-services-core.git',
-  tag: 'vx.x.x'
-```
+- Increment the version number (normally found in `lib/engine_name/version.rb`)
 
 - Run `bundle install` (**Critical** failure to do so can lead to build issues on the CI server)
 
@@ -56,43 +24,27 @@ gem 'digital_services_core',
 
 - Assuming build is successful merge the PR in GitHub
 
-- Ensure `master` is checked out and then create tag `git tag -a vx.x.x -m "Release of x.x.x"`
+- Check out master and `git pull`
+
+- Create tag `git tag -a vx.x.x -m "Release of x.x.x"`
 
 - Push tag to GitHub `git push origin vx.x.x`
 
-## [Front office core](https://github.com/EnvironmentAgency/front-office-core)
-
-Simply follow the same process as [Waste exemptions shared](#waste-exemptions-shared).
-
-## [Back office core](https://github.com/EnvironmentAgency/back-office-core)
-
-Simply follow the same process as [Waste exemptions shared](#waste-exemptions-shared).
-
 ## [Waste exemptions](https://github.com/EnvironmentAgency/waste-exemptions)
 
-- When ready for release create branch off `develop` called *release/update_to_version_x-x-x*.
+- When ready for release create branch off `develop` called *release/x-x-x*.
 
 - Push empty commit as normal with message
 
-> Update version to x.x.x ready for release
+> Release of version x.x.x
 >
-> This covers all work required to prepare the Waste exemptions registration service for its next release.
+> Creating a production ready release of the Waste exemptions front office service.
 
-- Update the version number (normally found in `config/initializers/version.rb`) to match
+- Increment the version number (normally found in `config/initializers/version.rb`)
 
-- Update the references to the core gems in the `Gemfile` to point to latest tag
+- Ensure the reference to the `waste_exemptions_shared` gem in the `Gemfile` is pointing to the latest tag
 
 ```ruby
-## EA/GovUK gems
-gem 'digital_services_core',
-  git: 'https://github.com/EnvironmentAgency/digital-services-core',
-  tag: 'vx.x.x'
-
-# Core components for EA Front Office services
-gem 'front_office_core',
-  git: 'https://github.com/EnvironmentAgency/front-office-core',
-  tag: 'vx.x.x'
-
 # Core components for WasteExemptions
 gem 'waste_exemptions_shared',
   git: 'https://github.com/EnvironmentAgency/waste-exemptions-shared',
@@ -109,7 +61,9 @@ gem 'waste_exemptions_shared',
 
 - Locally checkout `develop` and `git pull` to get latest changes
 
-- Then checkout `master` and merge `develop` into it `git merge develop`
+- Checkout `master` and do a `git pull` (just to make sure you have the latest)
+
+- Merge `develop` into it `git merge develop`
 
 - Push `master` using `git push` (no need to force push)
 
@@ -119,30 +73,11 @@ gem 'waste_exemptions_shared',
 
 ## [Waste exemptions back office](https://github.com/EnvironmentAgency/waste-exemptions-back-office)
 
-Simply follow the same process as [Waste exemptions](#waste-exemptions) only change the initial empty commit message to be
+Follow the same process as [Waste exemptions](#waste-exemptions) only change the initial empty commit message to be
 
-> Update version to x.x.x ready for release
+> Release of version x.x.x
 >
-> This covers all work required to prepare the Waste exemptions registration back office service for its next release.
-
-And update the references to the core gems as follows
-
-```ruby
-## EA/GovUK gems
-gem 'digital_services_core',
-  git: 'https://github.com/EnvironmentAgency/digital-services-core',
-  tag: 'vx.x.x'
-
-# Core components for EA Back Office services
-gem 'back_office_core',
-  git: 'https://github.com/EnvironmentAgency/back-office-core',
-  tag: 'vx.x.x'
-
-# Core components for WasteExemptions
-gem 'waste_exemptions_shared',
-  git: 'https://github.com/EnvironmentAgency/waste-exemptions-shared',
-  tag: 'vx.x.x'
-```
+> Creating a production ready release of the Waste exemptions back office service.
 
 ## Questions
 

--- a/style/README.md
+++ b/style/README.md
@@ -2,6 +2,6 @@
 
 Our guides on style.
 
-- [Javascript](javascript.md)
+- [JavaScript](javascript.md)
 - [Markdown](markdown.md)
 - [Ruby](ruby.md)

--- a/style/javascript.md
+++ b/style/javascript.md
@@ -1,4 +1,4 @@
-# Javascript
+# JavaScript
 
 We have adopted [StandardJS](http://standardjs.com/) for all JavaScript written either in NodeJS apps or in client side scripting.
 


### PR DESCRIPTION
The latest release of [WEX](https://github.com/EnvironmentAgency/waste-exemptions/releases/tag/v1.1.3) (and the corresponding [back office](https://github.com/EnvironmentAgency/waste-exemptions-back-office/releases/tag/v1.1.3) included changes which reduced the gem dependency down from 4 to 1.

Essentially the **Digital Service Core**, **Back office core** and **Front office core** were deprecated, and relevant functionality merged into [Waste exemptions shard](https://github.com/EnvironmentAgency/waste-exemptions-shared).

This updates the guides to reflect this change.